### PR TITLE
Support options for `decrypt` and custom `nonceInfo`

### DIFF
--- a/ece.ts
+++ b/ece.ts
@@ -189,23 +189,14 @@ export async function decrypt(
   headerOrOptions?: Header | ECECryptoOptions,
 ): Promise<ArrayBuffer> {
   let options: ECECryptoOptions;
-  let header: Header;
   if (headerOrOptions instanceof Header) {
-    header = headerOrOptions;
     options = { header: headerOrOptions };
-  } else if (headerOrOptions) {
-    if (headerOrOptions.header instanceof Header) {
-      header = headerOrOptions.header;
-    } else {
-      header = new Header(headerOrOptions.header || {});
-    }
-    options = { ...headerOrOptions, header };
   } else {
-    header = Header.fromBytes(data);
-    options = { header };
+    options = headerOrOptions || {};
   }
 
   const crypto = new ECECrypto(secret, options);
+  const header = crypto.header;
   data = data.slice(header.byteLength);
 
   const recordsNum = data.byteLength / header.rs;

--- a/ece.ts
+++ b/ece.ts
@@ -195,6 +195,8 @@ export async function decrypt(
     options = headerOrOptions || {};
   }
 
+  options.header ||= Header.fromBytes(data);
+
   const crypto = new ECECrypto(secret, options);
   const header = crypto.header;
   data = data.slice(header.byteLength);

--- a/ece_crypto.ts
+++ b/ece_crypto.ts
@@ -4,6 +4,7 @@ import { CEK_INFO, KEY_LENGTH, NONCE_INFO, NONCE_LENGTH } from "./const.ts";
 export interface ECECryptoOptions {
   header?: Header | HeaderOptions;
   info?: Uint8Array;
+  nonceInfo?: Uint8Array;
   subtleCrypto?: SubtleCrypto;
 }
 
@@ -15,6 +16,7 @@ export interface ECECryptoOptions {
  */
 export class ECECrypto {
   public readonly info: Uint8Array;
+  public readonly nonceInfo: Uint8Array;
   public readonly header: Header;
   public readonly crypto: SubtleCrypto;
 
@@ -35,6 +37,7 @@ export class ECECrypto {
     {
       header = new Header({}),
       info = CEK_INFO,
+      nonceInfo = NONCE_INFO,
       subtleCrypto = crypto.subtle,
     }: ECECryptoOptions,
   ) {
@@ -42,6 +45,7 @@ export class ECECrypto {
     this.info = info;
     this.header = header instanceof Header ? header : new Header(header);
     this.crypto = subtleCrypto;
+    this.nonceInfo = nonceInfo;
   }
 
   protected async getPRK(): Promise<ArrayBuffer> {
@@ -80,7 +84,7 @@ export class ECECrypto {
     if (this.nonce === null) {
       this.nonce = await this.hmacSha256(
         await this.getPRK(),
-        NONCE_INFO,
+        this.nonceInfo,
         NONCE_LENGTH,
       );
     }


### PR DESCRIPTION
Thanks for this library!

These changes are useful for using this lib for encryption for web push.