### PR TITLE
configure github actions workflow and publish to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           deno-version: "1"
 
+      - name: Lint
+        run: make lint
+
+      - name: Check Format
+        run: make fmt-check
+
       - name: Run Tests
         run: make test
 
@@ -53,5 +59,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ steps.extract_tag.outputs.result }}
-        run: |
-          npm publish --provenance
+        run: npm publish --provenance

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  push:
+    branches: ['*']
+    tags: ['v*']
+  pull_request:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract Tag
+        id: extract_tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prefix = 'refs/tags/v';
+            const ref = context.ref;
+            return ref.startsWith(prefix) ? ref.substring(prefix.length) : '';
+          result-encoding: string
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1"
+
+      - name: Run Tests
+        run: make test
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Prepare for NPM
+        run: make "npm/${{ steps.extract_tag.outputs.result || '0.0.0' }}"
+
+      - name: Publish to NPM
+        if: steps.extract_tag.outputs.result
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ steps.extract_tag.outputs.result }}
+        run: |
+          npm publish --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .direnv/
-
+/npm

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ tag/%: test
 	sed -i -E "s|deno.land/x/http_ece@(v[0-9]\.[0-9]\.[0-9])|deno.land/x/http_ece@$(@F)|g" *; \
 	git commit -m "tag version $(@F)" .; \
 	git tag $(@F)
+
+.PHONY: npm
+npm/%:
+	deno run -A ./scripts/build_npm.ts $(@F)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ lint:
 fmt:
 	deno fmt
 
+.PHONY: fmt-check
+fmt-check:
+	deno fmt --check
+
 .PHONY: test
 test: lint fmt
 	deno test

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ console.log(new TextDecoder().decode(decrypted));
 // output: I am the walrus
 ```
 
+or this is available on NPM as `TODO` for use in browsers.
+
 ## Features
 
 - `aes128gcm` encryption and decryption

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,8 @@
         "."
       ],
       "exclude": [
-        "dist/"
+        "dist/",
+        "npm/"
       ]
     },
     "rules": {
@@ -24,7 +25,8 @@
         "."
       ],
       "exclude": [
-        "dist/"
+        "dist/",
+        "npm/"
       ]
     },
     "options": {

--- a/deno.json
+++ b/deno.json
@@ -4,15 +4,13 @@
     "strict": true
   },
   "lint": {
-    "files": {
-      "include": [
-        "."
-      ],
-      "exclude": [
-        "dist/",
-        "npm/"
-      ]
-    },
+    "include": [
+      "."
+    ],
+    "exclude": [
+      "dist/",
+      "npm/"
+    ],
     "rules": {
       "tags": [
         "recommended"
@@ -20,17 +18,13 @@
     }
   },
   "fmt": {
-    "files": {
-      "include": [
-        "."
-      ],
-      "exclude": [
-        "dist/",
-        "npm/"
-      ]
-    },
-    "options": {
-      "indentWidth": 2
-    }
+    "include": [
+      "."
+    ],
+    "exclude": [
+      "dist/",
+      "npm/"
+    ],
+    "indentWidth": 2
   }
 }

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,7 +1,7 @@
 import { build, emptyDir } from "https://deno.land/x/dnt@0.37.0/mod.ts";
 
 const version = Deno.args[0];
-if (!version) throw new Error('Missing version');
+if (!version) throw new Error("Missing version");
 
 await emptyDir("./npm");
 
@@ -16,7 +16,8 @@ await build({
   package: {
     name: "http_ece",
     version,
-    description: "An implementation of HTTP Encrypted Content-Encoding scheme (RFC 8188).",
+    description:
+      "An implementation of HTTP Encrypted Content-Encoding scheme (RFC 8188).",
     license: "MIT",
     repository: {
       type: "git",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,0 +1,33 @@
+import { build, emptyDir } from "https://deno.land/x/dnt@0.37.0/mod.ts";
+
+const version = Deno.args[0];
+if (!version) throw new Error('Missing version');
+
+await emptyDir("./npm");
+
+await build({
+  entryPoints: ["./mod.ts"],
+  outDir: "./npm",
+  compilerOptions: {
+    lib: ["ES2021", "DOM"],
+  },
+  test: false,
+  shims: {},
+  package: {
+    name: "http_ece",
+    version,
+    description: "An implementation of HTTP Encrypted Content-Encoding scheme (RFC 8188).",
+    license: "MIT",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/negrel/http_ece.git",
+    },
+    bugs: {
+      url: "https://github.com/negrel/http_ece/issues",
+    },
+  },
+  postBuild() {
+    Deno.copyFileSync("LICENSE", "npm/LICENSE");
+    Deno.copyFileSync("README.md", "npm/README.md");
+  },
+});


### PR DESCRIPTION
closes #3

This adds a workflow that runs on branches, prs and tags, and for version tags it also does the publish. It also signs the published archive using `--provenance` and the id token github generates.

## TODO
- [x] the name I used here is taken already by another package. Maybe update it to `@yournpmusername/http_ece`?
- [x] an `NPM_TOKEN` secret needs configuring with an npm token configured for machines (i.e. no otp)
